### PR TITLE
Initial work on webhook service and RBAC types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 # Folders
 _obj
 _test
+.vscode
+bin
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+ifeq ($(origin VERSION), undefined)
+  VERSION=$(git rev-parse --short HEAD)
+endif
+GOOS=$(shell go env GOOS)
+GOARCH=$(shell go env GOARCH)
+REPOPATH = kismatic/kubernetes-rbac
+
+build: vendor
+	go build -o bin/kubernetes-rbac -ldflags "-X $(REPOPATH).Version=$(VERSION)" ./kubernetes-rbac.go
+
+test: bin/glide
+	go test $(shell ./bin/glide novendor)
+
+vet: bin/glide
+	go vet $(shell ./bin/glide novendor)
+
+fmt: bin/glide
+	go fmt $(shell ./bin/glide novendor)
+
+run:
+	./bin/kubernetes-ldap
+
+vendor: bin/glide
+	./bin/glide install
+
+bin/glide:
+	@echo "Downloading glide"
+	mkdir -p bin
+	curl -L https://github.com/Masterminds/glide/releases/download/0.10.2/glide-0.10.2-$(GOOS)-$(GOARCH).tar.gz | tar -xz -C bin
+	mv bin/$(GOOS)-$(GOARCH)/glide bin/glide
+	rm -r bin/$(GOOS)-$(GOARCH)

--- a/api/types.go
+++ b/api/types.go
@@ -1,0 +1,67 @@
+package api
+
+const (
+	APIGroupAll        = "*"
+	ResourceAll        = "*"
+	VerbAll            = "*"
+	NonResourceAll     = "*"
+	NamespaceAll       = "*"
+	GroupKind          = "Group"
+	ServiceAccountKind = "ServiceAccount"
+	UserKind           = "User"
+)
+
+// PolicyRule holds information that describes a policy rule, but does not contain information
+// about who the rule applies to or which namespace the rule applies to.
+type PolicyRule struct {
+	// Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.
+	// Cannot be empty.
+	Verbs []string `json:"verbs"`
+	// APIGroups is the name of the APIGroup that contains the resources. If multiple API groups are specified, any action requested against one of
+	// the enumerated resources in any API group will be allowed. Cannot be empty.
+	APIGroups []string `json:"apiGroups"`
+	// Resources is a list of resources this rule applies to.  ResourceAll represents all resources. Cannot be empty.
+	Resources []string `json:"resources"`
+	// ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
+	ResourceNames []string `json:"resourceNames,omitempty"`
+	// NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
+	// Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
+	NonResourceURLs []string `json:"nonResourceURLs,omitempty"`
+}
+
+// Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference,
+// or a value for non-objects such as user and group names.
+type Subject struct {
+	// Kind of object being referenced. Values defined by this API group are "User", "Group", and "ServiceAccount".
+	// If the Authorizer does not recognize the kind value, the Authorizer should report an error.
+	Kind string `json:"kind"`
+	// Name of the object being referenced.
+	Name string `json:"name"`
+	// Namespace of the referenced object.  If the object kind is non-namespace, such as "User" or "Group", and this value is not empty
+	// the Authorizer should report an error.
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
+type Role struct {
+	// Name of the role. Must be unique within the namespace.
+	Name string `json:"name,omitempty"`
+	// Namespace where this role exists.
+	Namespace string `json:"namespace,omitempty"`
+	// Rules holds all the PolicyRules for this Role
+	Rules []PolicyRule `json:"rules"`
+}
+
+// RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace.
+// It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given
+// namespace only have effect in that namespace.
+type RoleBinding struct {
+	// Name of the role binding. Must be unique within the namespace.
+	Name string `json:"name,omitempty"`
+	// Namespace where this rolebinding exists.
+	Namespace string `json:"namespace,omitempty"`
+	// Subjects holds references to the objects the role applies to.
+	Subjects []Subject `json:"subjects"`
+	// Role in the current namespace or a ClusterRole in the global namespace.
+	Role `json:"role"`
+}

--- a/api/types.go
+++ b/api/types.go
@@ -63,5 +63,5 @@ type RoleBinding struct {
 	// Subjects holds references to the objects the role applies to.
 	Subjects []Subject `json:"subjects"`
 	// Role in the current namespace or a ClusterRole in the global namespace.
-	Role `json:"role"`
+	Role Role `json:"role"`
 }

--- a/authorization/policy.go
+++ b/authorization/policy.go
@@ -1,0 +1,62 @@
+package authorization
+
+import "github.com/kismatic/kubernetes-rbac/api"
+
+// RuleValidator determines if the APIAction is allowed by a PolicyRule
+type RuleValidator func(api.PolicyRule, APIAction) bool
+
+// IsAuthorized determines whether the policy allows the action requested by the user
+func IsAuthorized(ruleGetter PolicyRuleGetter, ar *Request) bool {
+
+	// Get all the PolicyRules that apply to the user in the given namespace
+	rules := ruleGetter.GetApplicableRules(ar.User, ar.Groups, ar.Action.Namespace)
+
+	// Depending on the request, we might be validating access to an API resource, or to
+	// a "NonResource" URL.
+	var validateRule RuleValidator = isResourceActionAllowed
+	if ar.Action.NonResourceURL != "" {
+		validateRule = isNonResourceAccessAllowed
+	}
+
+	// Find a rule that allows the requested action
+	for _, r := range rules {
+		if validateRule(r, ar.Action) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isResourceActionAllowed(rule api.PolicyRule, action APIAction) bool {
+	allowsGroup := contains(rule.APIGroups, api.APIGroupAll) || contains(rule.APIGroups, action.APIGroup)
+	allowsVerb := contains(rule.Verbs, api.VerbAll) || contains(rule.Verbs, action.Verb)
+	allowsResource := contains(rule.Resources, api.ResourceAll) || contains(rule.Resources, action.Resource)
+
+	// Handle resource names whitelist
+	allowsResourceName := false
+	if len(rule.ResourceNames) == 0 { // No whitelist defined
+		allowsResourceName = true
+	} else {
+		// Verify resource name is in whitelist
+		allowsResourceName = contains(rule.ResourceNames, action.Name)
+	}
+
+	return allowsGroup && allowsVerb && allowsResource && allowsResourceName
+}
+
+func isNonResourceAccessAllowed(rule api.PolicyRule, action APIAction) bool {
+	allowsVerb := contains(rule.Verbs, api.VerbAll) || contains(rule.Verbs, action.Verb)
+	allowsNonResource := contains(rule.NonResourceURLs, api.NonResourceAll) || contains(rule.NonResourceURLs, action.NonResourceURL)
+
+	return allowsVerb && allowsNonResource
+}
+
+func contains(set []string, value string) bool {
+	for _, e := range set {
+		if e == value {
+			return true
+		}
+	}
+	return false
+}

--- a/authorization/policy_test.go
+++ b/authorization/policy_test.go
@@ -1,0 +1,341 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/kismatic/kubernetes-rbac/api"
+)
+
+type dummyRuleGetter struct {
+	rules []api.PolicyRule
+}
+
+func (drg dummyRuleGetter) GetApplicableRules(user string, groups []string, namespace string) []api.PolicyRule {
+	return drg.rules
+}
+
+func TestIsAuthorized(t *testing.T) {
+
+	req := &Request{
+		Action: APIAction{
+			Verb:      "GET",
+			Resource:  "pods",
+			Name:      "nginx",
+			Namespace: "project-1",
+		},
+	}
+
+	rulesThatAuthorize := []api.PolicyRule{
+		{
+			// Allow all access
+			Verbs:     []string{"*"},
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+		},
+		{
+			// Allow all GET requests
+			Verbs:     []string{"GET"},
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+		},
+		{
+			// Allow all requests on the pods resource
+			Verbs:     []string{"*"},
+			APIGroups: []string{"*"},
+			Resources: []string{"pods"},
+		},
+		{
+			// Allow GET requests on the pods resource
+			Verbs:     []string{"GET"},
+			APIGroups: []string{"*"},
+			Resources: []string{"pods"},
+		},
+	}
+
+	for i, r := range rulesThatAuthorize {
+		drg := dummyRuleGetter{[]api.PolicyRule{r}}
+
+		if !IsAuthorized(drg, req) {
+			t.Error("Test case", i, "failed. Expected authorized = true, but got false.")
+		}
+	}
+}
+
+func TestIsNotAuthorized(t *testing.T) {
+
+	req := &Request{
+		Action: APIAction{
+			Verb:      "GET",
+			Resource:  "pods",
+			Name:      "nginx",
+			Namespace: "project-1",
+		},
+	}
+
+	rulesThatDontAuthorize := []api.PolicyRule{
+		{
+			// Allow POST requests on any resource
+			Verbs:     []string{"POST"},
+			APIGroups: []string{"*"},
+			Resources: []string{"*"},
+		},
+		{
+			// Allow any verb on the nodes resource
+			Verbs:     []string{"*"},
+			APIGroups: []string{"*"},
+			Resources: []string{"nodes"},
+		},
+		{
+			// Allow GET on the nodes resource
+			Verbs:     []string{"GET"},
+			APIGroups: []string{"*"},
+			Resources: []string{"nodes"},
+		},
+		{
+			// Allow POST on the pods resource
+			Verbs:     []string{"POST"},
+			APIGroups: []string{"*"},
+			Resources: []string{"pods"},
+		},
+	}
+
+	for i, r := range rulesThatDontAuthorize {
+		drg := dummyRuleGetter{[]api.PolicyRule{r}}
+		auth := IsAuthorized(drg, req)
+
+		if auth {
+			t.Error("Test case", i, "failed. Expected authorized = false, but got authorized = true.")
+		}
+	}
+}
+
+func TestIsAuthorizedWithResourceNames(t *testing.T) {
+
+	req := &Request{
+		Action: APIAction{
+			Verb:      "GET",
+			Resource:  "pods",
+			Name:      "nginx",
+			Namespace: "project-1",
+		},
+	}
+
+	rulesThatAuthorize := []api.PolicyRule{
+		{
+			// Allow any request on any resource, where the resource name is nginx
+			Verbs:         []string{"*"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"*"},
+			ResourceNames: []string{"nginx"},
+		},
+		{
+			// Allow GET requests on any resource, where the resource name is nginx
+			Verbs:         []string{"GET"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"*"},
+			ResourceNames: []string{"nginx"},
+		},
+		{
+			// Allow any requests on the pods resource, where the resource name is nginx
+			Verbs:         []string{"*"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"pods"},
+			ResourceNames: []string{"nginx"},
+		},
+		{
+			// Allow GET requests on the pods resource, where the resource name is nginx
+			Verbs:         []string{"GET"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"pods"},
+			ResourceNames: []string{"nginx"},
+		},
+	}
+
+	for i, r := range rulesThatAuthorize {
+		drg := dummyRuleGetter{[]api.PolicyRule{r}}
+
+		if !IsAuthorized(drg, req) {
+			t.Error("Test case", i, "failed. Expected authorized = true, but got false.")
+		}
+	}
+}
+
+func TestIsNotAuthorizedWithResourceNames(t *testing.T) {
+	req := &Request{
+		Action: APIAction{
+			Verb:      "GET",
+			Resource:  "pods",
+			Name:      "nginx",
+			Namespace: "project-1",
+		},
+	}
+
+	rulesThatDontAuth := []api.PolicyRule{
+		{
+			// Allow any request on resources where the name is "other"
+			Verbs:         []string{"*"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"*"},
+			ResourceNames: []string{"other"},
+		},
+		{
+			// Allow GET requests on resources where the name is "other"
+			Verbs:         []string{"GET"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"*"},
+			ResourceNames: []string{"other"},
+		},
+		{
+			// Allow any requests on "pods" resources where the resource name is "other"
+			Verbs:         []string{"*"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"pods"},
+			ResourceNames: []string{"other"},
+		},
+		{
+			// Allow GET requests on "pods" resources where the resource name is "other"
+			Verbs:         []string{"GET"},
+			APIGroups:     []string{"*"},
+			Resources:     []string{"pods"},
+			ResourceNames: []string{"other"},
+		},
+	}
+
+	for i, r := range rulesThatDontAuth {
+		drg := dummyRuleGetter{[]api.PolicyRule{r}}
+
+		if IsAuthorized(drg, req) {
+			t.Error("Test case", i, "failed. Expected authorized = false, but got true.")
+		}
+	}
+}
+
+func TestIsAuthorizedNonResourceRequest(t *testing.T) {
+
+	req := &Request{
+		Action: APIAction{
+			Verb:           "GET",
+			NonResourceURL: "/api",
+		},
+	}
+
+	rulesThatAuthorize := []api.PolicyRule{
+		{
+			// Allow GET access to the /api endpoint
+			Verbs:           []string{"GET"},
+			NonResourceURLs: []string{"/api"},
+		},
+		{
+			// Allow GET access to all endpoints
+			Verbs:           []string{"GET"},
+			NonResourceURLs: []string{"*"},
+		},
+		{
+			// Allow any verb on the /api endpoint
+			Verbs:           []string{"*"},
+			NonResourceURLs: []string{"/api"},
+		},
+		{
+			// Allow any verb on any endpoint
+			Verbs:           []string{"*"},
+			NonResourceURLs: []string{"*"},
+		},
+	}
+
+	for i, r := range rulesThatAuthorize {
+		drg := dummyRuleGetter{[]api.PolicyRule{r}}
+
+		if !IsAuthorized(drg, req) {
+			t.Error("Test case", i, "failed. Expected authorized = true, but got false.")
+		}
+	}
+}
+
+func TestIsNotAuthorizedNonResourceRequest(t *testing.T) {
+
+	req := &Request{
+		Action: APIAction{
+			Verb:           "GET",
+			NonResourceURL: "/api",
+		},
+	}
+
+	rulesThatDontAuthorize := []api.PolicyRule{
+		{
+			// Same URL, different verb
+			Verbs:           []string{"POST"},
+			NonResourceURLs: []string{"/api"},
+		},
+		{
+			// Same verb, different URL
+			Verbs:           []string{"GET"},
+			NonResourceURLs: []string{"/other"},
+		},
+		{
+			// All verbs, different URL
+			Verbs:           []string{"*"},
+			NonResourceURLs: []string{"/other"},
+		},
+		{
+			// Different verb, all URLs
+			Verbs:           []string{"POST"},
+			NonResourceURLs: []string{"*"},
+		},
+	}
+
+	for i, r := range rulesThatDontAuthorize {
+		drg := dummyRuleGetter{[]api.PolicyRule{r}}
+
+		if IsAuthorized(drg, req) {
+			t.Error("Test case", i, "failed. Expected authorized = false, but got true.")
+		}
+	}
+}
+
+func TestIsAuthorizedMultipleRules(t *testing.T) {
+
+	req := &Request{
+		Action: APIAction{
+			Verb:      "GET",
+			Resource:  "pods",
+			Name:      "nginx",
+			Namespace: "project-1",
+		},
+	}
+
+	drg := dummyRuleGetter{
+		[]api.PolicyRule{
+			{
+				Verbs:     []string{"POST"},
+				APIGroups: []string{"*"},
+				Resources: []string{"*"},
+			},
+			{
+				Verbs:     []string{"*"},
+				APIGroups: []string{"*"},
+				Resources: []string{"nodes"},
+			},
+			{
+				Verbs:     []string{"GET"},
+				APIGroups: []string{"*"},
+				Resources: []string{"nodes"},
+			},
+			{
+				Verbs:     []string{"POST"},
+				APIGroups: []string{"*"},
+				Resources: []string{"pods"},
+			},
+			// This last rule is the one that allows the request
+			{
+				Verbs:     []string{"GET"},
+				APIGroups: []string{"*"},
+				Resources: []string{"pods"},
+			},
+		},
+	}
+
+	if !IsAuthorized(drg, req) {
+		t.Error("Expected isAuthorized = true, but got false")
+	}
+
+}

--- a/authorization/types.go
+++ b/authorization/types.go
@@ -1,0 +1,37 @@
+package authorization
+
+import "github.com/kismatic/kubernetes-rbac/api"
+
+// APIAction is the action that is being authorized on the given resource.
+type APIAction struct {
+	// Verb is the Kubernetes resource API verb.
+	Verb string
+	// APIGroup is the name of the Kubernetes API group that contains the resource.
+	APIGroup string
+	// Resource is the name of the Kubernetes resource being accessed.
+	Resource string
+	// Subresource is the name of the subresource.
+	Subresource string
+	// Name is the name of the resource that receives the action.
+	Name string
+	// Namespace is the namespace of the resource that receives the action.
+	Namespace string
+	// NonResourceURL is the URL path of a non-resource request (e.g. "/api").
+	NonResourceURL string
+}
+
+// Request to be authorized according to defined policy.
+type Request struct {
+	// User is the name of the user performing the request.
+	User string
+	// Groups is a list of group names that the user belongs to.
+	Groups []string
+	// Action is what the user is trying to do in this request.
+	Action APIAction
+}
+
+type PolicyRuleGetter interface {
+	// GetApplicableRules gets the policy rules that apply to the given user/group in the
+	// specified namespace.
+	GetApplicableRules(user string, groups []string, namespace string) []api.PolicyRule
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,6 @@
+hash: c6bca4f3a8ceddd86e7711b7cf9c3c48c268801c3f4cf05dddd67c9b07dd3c59
+updated: 2016-06-13T10:59:08.0105232-04:00
+imports:
+- name: github.com/spf13/pflag
+  version: 367864438f1b1a3c7db4da06a2f55b144e6784e0
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,3 @@
+package: github.com/kismatic/kubernetes-rbac
+import:
+- package: github.com/spf13/pflag

--- a/kubernetes-rbac.go
+++ b/kubernetes-rbac.go
@@ -15,8 +15,36 @@
 // Package kubernetes-rbac contains the role-based access control (RBAC) plug-in for Kubernetes.
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/kismatic/kubernetes-rbac/webhook"
+	flag "github.com/spf13/pflag"
+)
+
+var flTLSCertFile = flag.String("tls-cert-file", "", "X509 certificate for HTTPS")
+var flTLSKeyFile = flag.String("tls-private-key-file", "", "X509 private key matching --tls-cert-file for HTTPS")
 
 func main() {
-  fmt.Printf("Coming soon!\n")
+	flag.Parse()
+
+	h := &webhook.AuthorizationHandler{}
+
+	http.Handle("/authorize", h)
+
+	if *flTLSCertFile == "" {
+		fmt.Fprintln(os.Stderr, "--tls-cert-file is required.")
+		os.Exit(1)
+	}
+
+	if *flTLSKeyFile == "" {
+		fmt.Fprintln(os.Stderr, "--tls-private-key-file is required.")
+		os.Exit(1)
+	}
+
+	log.Fatal(http.ListenAndServeTLS(":4000", *flTLSCertFile, *flTLSKeyFile, nil))
+
 }

--- a/webhook/handler.go
+++ b/webhook/handler.go
@@ -1,0 +1,39 @@
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type AuthorizationHandler struct {
+}
+
+func (ah *AuthorizationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	sar := &SubjectAccessReview{}
+	if err := json.NewDecoder(r.Body).Decode(sar); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Printf("%+v\n", sar)
+	if sar.Spec.NonResourceAttributes != nil {
+		fmt.Printf("%+v\n", *sar.Spec.NonResourceAttributes)
+	}
+
+	if sar.Spec.ResourceAttributes != nil {
+		fmt.Printf("%+v\n", *sar.Spec.ResourceAttributes)
+	}
+
+	// Allow all access
+	sar.Status.Allowed = true
+
+	payload, err := json.Marshal(sar)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(payload)
+}

--- a/webhook/handler.go
+++ b/webhook/handler.go
@@ -26,7 +26,7 @@ func (ah *AuthorizationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		fmt.Printf("%+v\n", *sar.Spec.ResourceAttributes)
 	}
 
-	// Allow all access
+	// Currently allows all access
 	sar.Status.Allowed = true
 
 	payload, err := json.Marshal(sar)

--- a/webhook/types.go
+++ b/webhook/types.go
@@ -1,0 +1,69 @@
+package webhook
+
+// SubjectAccessReview checks whether or not a user or group can perform an action.
+type SubjectAccessReview struct {
+	Kind string `json:"kind,omitempty"`
+
+	APIVersion string `json:"apiVersion,omitempty"`
+
+	// Spec holds information about the request being evaluated
+	Spec SubjectAccessReviewSpec `json:"spec"`
+
+	// Status indicates whether the request is allowed or not
+	Status SubjectAccessReviewStatus `json:"status,omitempty"`
+}
+
+// SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes
+// and NonResourceAuthorizationAttributes must be set
+type SubjectAccessReviewSpec struct {
+	// ResourceAuthorizationAttributes describes information for a resource access request
+	ResourceAttributes *ResourceAttributes `json:"resourceAttributes,omitempty"`
+	// NonResourceAttributes describes information for a non-resource access request
+	NonResourceAttributes *NonResourceAttributes `json:"nonResourceAttributes,omitempty"`
+
+	// User is the user you're testing for.
+	// If you specify "User" but not "Group", then is it interpreted as "What if User were not a member of any groups
+	User string `json:"user,omitempty"`
+	// Groups is the groups you're testing for.
+	Groups []string `json:"group,omitempty"`
+	// Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer
+	// it needs a reflection here.
+	Extra map[string][]string `json:"extra,omitempty"`
+}
+
+// ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface
+type ResourceAttributes struct {
+	// Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces
+	// "" (empty) is defaulted for LocalSubjectAccessReviews
+	// "" (empty) is empty for cluster-scoped resources
+	// "" (empty) means "all" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview
+	Namespace string `json:"namespace,omitempty"`
+	// Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  "*" means all.
+	Verb string `json:"verb,omitempty"`
+	// Group is the API Group of the Resource.  "*" means all.
+	Group string `json:"group,omitempty"`
+	// Version is the API Version of the Resource.  "*" means all.
+	Version string `json:"version,omitempty"`
+	// Resource is one of the existing resource types.  "*" means all.
+	Resource string `json:"resource,omitempty"`
+	// Subresource is one of the existing resource types.  "" means none.
+	Subresource string `json:"subresource,omitempty"`
+	// Name is the name of the resource being requested for a "get" or deleted for a "delete". "" (empty) means all.
+	Name string `json:"name,omitempty"`
+}
+
+// NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface
+type NonResourceAttributes struct {
+	// Path is the URL path of the request
+	Path string `json:"path,omitempty"`
+	// Verb is the standard HTTP verb
+	Verb string `json:"verb,omitempty"`
+}
+
+// SubjectAccessReviewStatus indicates whether the request is allowed or not
+type SubjectAccessReviewStatus struct {
+	// Allowed is required.  True if the action would be allowed, false otherwise.
+	Allowed bool `json:"allowed"`
+	// Reason is optional.  It indicates why a request was allowed or denied.
+	Reason string `json:"reason,omitempty"`
+}


### PR DESCRIPTION
The webhook service currently allows all requests to go through.

Added RBAC types that were upstreamed to Kubernetes, but removed some of the K8s specifics that we probably won't need on our side.